### PR TITLE
Moving NotFoundHandler to Handler namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ details.
 
 ### Changed
 
-- Nothing.
+- [#8](https://github.com/laminas/laminas-stratigility/pull/8) As the `NotFoundHandler` is technically a request handler, we are moving it to the `Handler` namespace with only implementing the `RequestHandlerInterface` instead of the `MiddlewareInterface`.
 
 ### Deprecated
 
-- Nothing.
+- [#8](https://github.com/laminas/laminas-stratigility/pull/8) Marking `NotFoundHandler` in the `Middleware` namespace as deprecated in favor of the new `NotFoundHandler` in the `Handler` namespace.
 
 ### Removed
 

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -17,9 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 use function sprintf;
 
-/**
- * @todo Remove the `MiddlewareInterface` implementation in v4.
- */
 final class NotFoundHandler implements RequestHandlerInterface
 {
     /**

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Stratigility\Handler;
+
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function sprintf;
+
+/**
+ * @todo Remove the `MiddlewareInterface` implementation in v4.
+ */
+final class NotFoundHandler implements RequestHandlerInterface
+{
+    /**
+     * @var callable
+     */
+    private $responseFactory;
+
+    /**
+     * @param callable $responseFactory A factory capable of returning an
+     *     empty ResponseInterface instance to update and return when returning
+     *     an 404 response.
+     */
+    public function __construct(callable $responseFactory)
+    {
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
+    }
+
+    /**
+     * Creates and retursn a 404 response.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var ResponseInterface $response */
+        $response = ($this->responseFactory)()
+            ->withStatus(StatusCode::STATUS_NOT_FOUND);
+        $response->getBody()->write(sprintf(
+            'Cannot %s %s',
+            $request->getMethod(),
+            (string) $request->getUri()
+        ));
+        return $response;
+    }
+}

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -37,7 +37,7 @@ final class NotFoundHandler implements RequestHandlerInterface
     }
 
     /**
-     * Creates and retursn a 404 response.
+     * Creates and returns a 404 response.
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -1,8 +1,9 @@
 <?php
+
 /**
- * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ * @see       https://github.com/laminas/laminas-stratigility for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-stratigility/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-stratigility/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -7,12 +7,11 @@
 
 declare(strict_types=1);
 
-namespace Zend\Stratigility\Handler;
+namespace Laminas\Stratigility\Handler;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use function sprintf;

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -17,13 +17,18 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 use function sprintf;
+use Zend\Stratigility\Handler\NotFoundHandler as NotFoundRequestHandler;
 
+/**
+ * @deprecated Will be removed in v4 in favor of {@see \Zend\Stratigility\Handler\NotFoundHandler}
+ */
 final class NotFoundHandler implements MiddlewareInterface
 {
+
     /**
-     * @var callable
+     * @var NotFoundRequestHandler
      */
-    private $responseFactory;
+    private $notFoundHandler;
 
     /**
      * @param callable $responseFactory A factory capable of returning an
@@ -32,23 +37,14 @@ final class NotFoundHandler implements MiddlewareInterface
      */
     public function __construct(callable $responseFactory)
     {
-        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
-            return $responseFactory();
-        };
+        $this->notFoundHandler = new NotFoundRequestHandler($responseFactory);
     }
 
     /**
-     * Creates and returns a 404 response.
+     * Uses the {@see \Zend\Stratigility\Handler\NotFoundHandler} to create a 404 response.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $response = ($this->responseFactory)()
-            ->withStatus(StatusCode::STATUS_NOT_FOUND);
-        $response->getBody()->write(sprintf(
-            'Cannot %s %s',
-            $request->getMethod(),
-            (string) $request->getUri()
-        ));
-        return $response;
+        return $this->notFoundHandler->handle($request);
     }
 }

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -10,13 +10,10 @@ declare(strict_types=1);
 
 namespace Laminas\Stratigility\Middleware;
 
-use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-
-use function sprintf;
 use Zend\Stratigility\Handler\NotFoundHandler as NotFoundRequestHandler;
 
 /**

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -14,10 +14,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Stratigility\Handler\NotFoundHandler as NotFoundRequestHandler;
+use Laminas\Stratigility\Handler\NotFoundHandler as NotFoundRequestHandler;
 
 /**
- * @deprecated Will be removed in v4 in favor of {@see \Zend\Stratigility\Handler\NotFoundHandler}
+ * @deprecated Will be removed in v4 in favor of {@see \Laminas\Stratigility\Handler\NotFoundHandler}
  */
 final class NotFoundHandler implements MiddlewareInterface
 {
@@ -38,7 +38,7 @@ final class NotFoundHandler implements MiddlewareInterface
     }
 
     /**
-     * Uses the {@see \Zend\Stratigility\Handler\NotFoundHandler} to create a 404 response.
+     * Uses the {@see \Laminas\Stratigility\Handler\NotFoundHandler} to create a 404 response.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Stratigility\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Zend\Stratigility\Handler\NotFoundHandler;
+
+class NotFoundHandlerTest extends TestCase
+{
+    public function testReturnsResponseWith404StatusAndErrorMessageInBody()
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->write('Cannot POST https://example.com/foo');
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->withStatus(404)->will([$response, 'reveal']);
+        $response->getBody()->will([$stream, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getUri()->willReturn('https://example.com/foo');
+
+        $responseFactory = function () use ($response) {
+            return $response->reveal();
+        };
+
+        $middleware = new NotFoundHandler($responseFactory);
+
+        $this->assertSame(
+            $response->reveal(),
+            $middleware->handle($request->reveal())
+        );
+    }
+}

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @see       https://github.com/zendframework/zend-stratigility for the canonical source repository
- * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (https://www.zend.com)
- * @license   https://github.com/zendframework/zend-stratigility/blob/master/LICENSE.md New BSD License
+ * @see       https://github.com/laminas/laminas-stratigility for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-stratigility/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-stratigility/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -7,13 +7,13 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Stratigility\Handler;
+namespace LaminasTest\Stratigility\Handler;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
-use Zend\Stratigility\Handler\NotFoundHandler;
+use Laminas\Stratigility\Handler\NotFoundHandler;
 
 class NotFoundHandlerTest extends TestCase
 {


### PR DESCRIPTION
This re-opens zendframework/zend-stratigility#192 and handles #1

#### Summary

As the NotFoundHandler is technically a RequestHandler, I am moving it to the Handler namespace instead while marking the NotFoundHandler in the Middleware namespace as deprecated.