### PR TITLE
Update v3 docs to reference laminas-httphandlerrunner

### DIFF
--- a/docs/book/v3/middleware.md
+++ b/docs/book/v3/middleware.md
@@ -6,6 +6,15 @@ Middleware is code that exists between the request and response, and which can
 take the incoming request, perform actions based on it, and either complete the
 response or pass delegation on to the next middleware in the queue.
 
+> ### Installation requirements
+>
+> The following example depends on the [laminas-httphandlerrunner](http://docs.laminas.dev/laminas-httphandlerrunner)
+> component. You can install it with the following command:
+>
+> ```bash
+> $ composer require laminas/laminas-httphandlerrunner
+> ```
+
 ```php
 // In public/index.php:
 use Laminas\Diactoros\Response;

--- a/docs/book/v3/middleware.md
+++ b/docs/book/v3/middleware.md
@@ -8,9 +8,9 @@ response or pass delegation on to the next middleware in the queue.
 
 ```php
 // In public/index.php:
-use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\Stratigility\Middleware\NotFoundHandler;
@@ -51,10 +51,10 @@ $app->pipe(new NotFoundHandler(function () {
 $server = new RequestHandlerRunner(
     $app,
     new SapiEmitter(),
-    function () {
+    static function () {
         return ServerRequestFactory::fromGlobals();
     },
-    function (\Throwable $e) {
+    static function (\Throwable $e) {
         $response = (new ResponseFactory())->createResponse(500);
         $response->getBody()->write(sprintf(
             'An error occurred: %s',

--- a/docs/book/v3/usage.md
+++ b/docs/book/v3/usage.md
@@ -7,8 +7,8 @@ Creating an application consists of 3 steps:
 - Instruct the server to listen for a request
 
 ```php
-use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\Stratigility\MiddlewarePipe;
@@ -19,10 +19,10 @@ $app    = new MiddlewarePipe();
 $server = new RequestHandlerRunner(
     $app,
     new SapiEmitter(),
-    function () {
+    static function () {
         return ServerRequestFactory::fromGlobals();
     },
-    function (\Throwable $e) {
+    static function (\Throwable $e) {
         $response = (new ResponseFactory())->createResponse(500);
         $response->getBody()->write(sprintf(
             'An error occurred: %s',

--- a/docs/book/v3/usage.md
+++ b/docs/book/v3/usage.md
@@ -1,5 +1,14 @@
 # Usage
 
+> ### Installation requirements
+>
+> The following example depends on the [laminas-httphandlerrunner](http://docs.laminas.dev/laminas-httphandlerrunner)
+> component. You can install it with the following command:
+>
+> ```bash
+> $ composer require laminas/laminas-httphandlerrunner
+> ```
+
 Creating an application consists of 3 steps:
 
 - Create middleware or a middleware pipeline


### PR DESCRIPTION
Previously, they were referencing a feature of laminas-diactoros that was removed with version 2 of that library. Since version 3 of Stratigility requires version 2 of Diactoros, we can safely remove all references to it, and replace them with references to laminas-httphandlerrunner.

Fixes #9