### PR TITLE
Proposed fix for #14

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -8,6 +8,8 @@ namespace Laminas\Stratigility;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
+use function is_int;
+
 /**
  * Utility methods
  */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -25,7 +25,7 @@ abstract class Utils
     public static function getStatusCode(Throwable $error, ResponseInterface $response): int
     {
         $errorCode = $error->getCode();
-        if ($errorCode >= 400 && $errorCode < 600) {
+        if (is_int($errorCode) && $errorCode >= 400 && $errorCode < 600) {
             return $errorCode;
         }
 

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -2,18 +2,18 @@
 
 /**
  * @see       https://github.com/laminas/laminas-stratigility for the canonical source repository
- * @copyright https://github.com/laminas/laminas-stratigility/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-stratigility/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
 namespace LaminasTest\Stratigility;
 
+use Exception;
 use Laminas\Diactoros\Response\TextResponse;
 use Laminas\Stratigility\Utils;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class UtilsTest extends TestCase
 {
@@ -22,9 +22,9 @@ class UtilsTest extends TestCase
         // PDO can throw exceptions with codes like this:
         $naughtyCode = '42S02';
 
-        $exception = new \Exception();
-        $reflection = new \ReflectionClass($exception);
-        $code = $reflection->getProperty('code');
+        $exception  = new Exception();
+        $reflection = new ReflectionClass($exception);
+        $code       = $reflection->getProperty('code');
         $code->setAccessible(true);
         $code->setValue($exception, $naughtyCode);
 

--- a/test/UtilsTest.php
+++ b/test/UtilsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-stratigility for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-stratigility/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-stratigility/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Stratigility;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Stratigility\Utils;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+class UtilsTest extends TestCase
+{
+    public function testGetStatusCodeNotFooledBySneakyStringsWithLeadingDigits()
+    {
+        // PDO can throw exceptions with codes like this:
+        $naughtyCode = '42S02';
+
+        $exception = new \Exception();
+        $reflection = new \ReflectionClass($exception);
+        $code = $reflection->getProperty('code');
+        $code->setAccessible(true);
+        $code->setValue($exception, $naughtyCode);
+
+        $actual = Utils::getStatusCode($exception, new TextResponse('I am a teapot.', 418));
+
+        Assert::assertEquals(418, $actual);
+    }
+}


### PR DESCRIPTION
Should fix #14 

Tests are difficult, or even impossible, to provide for this. PDOException is allowed to return strings from getCode(), but PHP makes it difficult or impossible for mere mortals to do the same.

Someone more involved should probably review this thoughtfully before merging. 

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Bugfix: master branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #14.
<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
