### PR TITLE
Simplify redirects of legacy docs

### DIFF
--- a/docs/book/api.md
+++ b/docs/book/api.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/api/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/api/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/creating-middleware.md
+++ b/docs/book/creating-middleware.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/creating-middleware/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/creating-middleware/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/error-handlers.md
+++ b/docs/book/error-handlers.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/error-handlers/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/error-handlers/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/executing-middleware.md
+++ b/docs/book/executing-middleware.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/executing-middleware/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/executing-middleware/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/install.md
+++ b/docs/book/install.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/install/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/install/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/middleware/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/middleware/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/migration.md
+++ b/docs/book/migration.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/migration/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/migration/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/migration/preparing-for-v3.md
+++ b/docs/book/migration/preparing-for-v3.md
@@ -171,6 +171,7 @@ no longer support operation directly within a double-pass architecture, this
 class will be removed.
 
 Methods that produce an instance include:
+
 - `MiddlewarePipe::__invoke()`
 - `NotFoundHandler::__invoke()`
 - `ErrorHandler::__invoke()`

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-stratigility/v3/usage/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = '/laminas-stratigility/v3/usage/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/v1/api.md
+++ b/docs/book/v1/api.md
@@ -183,7 +183,7 @@ you will need to:
 - Create and return a concrete response type, OR
 - Operate on a response returned by invoking the delegate.
 
-### Providing an altered request:
+### Providing an altered request
 
 ```php
 // Standard invokable:
@@ -266,7 +266,6 @@ return $delegate->process($request);
 
 **Middleware should always return a response, and, if it cannot, return the
 result of delegation.**
-
 
 ### Raising an error condition
 
@@ -379,7 +378,7 @@ Additionally, it provides access to the original response created by the server 
 
 Stratigility provides several concrete middleware implementations.
 
-#### ErrorHandler and NotFoundHandler
+### ErrorHandler and NotFoundHandler
 
 These two middleware allow you to provide handle PHP errors and exceptions, and
 404 conditions, respectively. You may read more about them in the

--- a/docs/book/v1/creating-middleware.md
+++ b/docs/book/v1/creating-middleware.md
@@ -46,7 +46,7 @@ function (
 ) : Psr\Http\Message\ResponseInterface
 ```
 
-### Legacy error middleware
+## Legacy error middleware
 
 - Deprecated since 1.3.0; to be removed in version 2.0.0. Please use the the
   `NotFoundHandler` and `ErrorHandler` detailed in the

--- a/docs/book/v1/executing-middleware.md
+++ b/docs/book/v1/executing-middleware.md
@@ -13,6 +13,7 @@ $app = new MiddlewarePipe();  // Middleware representing the application
 $app->pipe('/api', $api);     // API middleware attached to the path "/api"
 ```
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Request path changes when path matched
 >
 > When you pipe middleware using a path (other than '' or '/'), the middleware

--- a/docs/book/v1/middleware.md
+++ b/docs/book/v1/middleware.md
@@ -44,6 +44,7 @@ this point, a "final handler" is composed by default to report 404 status.
 So, concisely put, _middleware are PHP callables that accept a request and
 response object, and do something with it_.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### http-interop middleware
 >
 > The above example demonstrates the legacy (pre-1.3.0) signature for

--- a/docs/book/v2/api.md
+++ b/docs/book/v2/api.md
@@ -59,7 +59,6 @@ The `MiddlewarePipe` is itself middleware, and can be executed in stacks that
 expect the `__invoke()` signature (via the `__invoke()` signature), or stacks
 expecting http-interop middleware signatures (via the `process()` method).
 
-
 When using `__invoke()`, the callable `$out` argument should either implement
 delegator/request handler interface from `http-interop/http-middleware`
 (depends on version you are using), or use the signature:
@@ -170,7 +169,7 @@ you will need to:
 - Create and return a concrete response type, OR
 - Operate on a response returned by invoking the delegate.
 
-### Providing an altered request:
+### Providing an altered request
 
 ```php
 // Standard invokable:
@@ -195,7 +194,7 @@ function ($request, DelegateInterface $delegate) use ($bodyParser)
 }
 ```
 
-### Providing an altered request and operating on the returned response:
+### Providing an altered request and operating on the returned response
 
 ```php
 function ($request, $response, $next) use ($bodyParser)
@@ -276,7 +275,6 @@ return $delegate->process($request);
 **Middleware should always return a response, and, if it cannot, return the
 result of delegation.**
 
-
 ### Raising an error condition
 
 If your middleware cannot complete &mdash; perhaps a database error occurred, a
@@ -304,7 +302,7 @@ your users.
 
 Stratigility provides several concrete middleware implementations.
 
-#### ErrorHandler and NotFoundHandler
+### ErrorHandler and NotFoundHandler
 
 These two middleware allow you to provide handle PHP errors and exceptions, and
 404 conditions, respectively. You may read more about them in the

--- a/docs/book/v2/executing-middleware.md
+++ b/docs/book/v2/executing-middleware.md
@@ -13,6 +13,7 @@ $app = new MiddlewarePipe();  // Middleware representing the application
 $app->pipe('/api', $api);     // API middleware attached to the path "/api"
 ```
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Request path changes when path matched
 >
 > When you pipe middleware using a path (other than '' or '/'), the middleware

--- a/docs/book/v2/middleware.md
+++ b/docs/book/v2/middleware.md
@@ -56,6 +56,7 @@ this point, a "final handler" is composed by default to report 404 status.
 So, concisely put, _middleware are PHP callables that accept a request object,
 and do something with it_.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### http-interop middleware
 >
 > The above example demonstrates the using the interfaces from the http-interop

--- a/docs/book/v2/migration.md
+++ b/docs/book/v2/migration.md
@@ -33,10 +33,10 @@ recommend the following:
 - Pipe `Laminas\Stratigility\Middleware\OriginalMessages` as the outermost layer of
   your application. This will inject the following request attributes into
   layers beneath it:
-    - `originalRequest`, mapping to the request provided to it at invocation.
-    - `originalResponse`, mapping to the response provided to it at invocation.
-    - `originalUri`, mapping to the URI composed by the request provided to it at
-      invocation.
+  - `originalRequest`, mapping to the request provided to it at invocation.
+  - `originalResponse`, mapping to the response provided to it at invocation.
+  - `originalUri`, mapping to the URI composed by the request provided to it at
+     invocation.
 
 You can then access these values within other middleware:
 

--- a/docs/book/v3/api.md
+++ b/docs/book/v3/api.md
@@ -58,7 +58,7 @@ Since your middleware needs to return a response, the instance receives the
 handler; if the last middleware in the queue calls on its handler, `Next` will
 execute the fallback request handler to generate a response to return.
 
-### Providing an altered request:
+### Providing an altered request
 
 ```php
 function ($request, RequestHandlerInterface $handler) use ($bodyParser)
@@ -72,7 +72,7 @@ function ($request, RequestHandlerInterface $handler) use ($bodyParser)
 }
 ```
 
-### Providing an altered request and operating on the returned response:
+### Providing an altered request and operating on the returned response
 
 ```php
 function ($request, RequestHandlerInterface $handler) use ($bodyParser)

--- a/docs/book/v3/executing-middleware.md
+++ b/docs/book/v3/executing-middleware.md
@@ -13,6 +13,7 @@ $app = new MiddlewarePipe();  // Middleware representing the application
 $app->pipe(new PathMiddlewareDecorator('/api', $api)); // API middleware attached to the path "/api"
 ```
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Request path changes when path matched
 >
 > When you use the `PathMiddlewareDecorator` using a path (other than '' or

--- a/docs/book/v3/middleware.md
+++ b/docs/book/v3/middleware.md
@@ -6,6 +6,7 @@ Middleware is code that exists between the request and response, and which can
 take the incoming request, perform actions based on it, and either complete the
 response or pass delegation on to the next middleware in the queue.
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Installation requirements
 >
 > The following example depends on the [laminas-httphandlerrunner](http://docs.laminas.dev/laminas-httphandlerrunner)

--- a/docs/book/v3/usage.md
+++ b/docs/book/v3/usage.md
@@ -1,5 +1,6 @@
 # Usage
 
+<!-- markdownlint-disable-next-line header-increment -->
 > ### Installation requirements
 >
 > The following example depends on the [laminas-httphandlerrunner](http://docs.laminas.dev/laminas-httphandlerrunner)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,15 +37,18 @@ nav:
         - "Creating Middleware": v1/creating-middleware.md
         - "Executing and composing middleware": v1/executing-middleware.md
         - "API Reference": v1/api.md
-    - "_hidden-legacy-page-links":
-        - "_install": install.md
-        - "_usage": usage.md
-        - "_middleware": middleware.md
-        - "_error-handlers": error-handlers.md
-        - "_creating-middleware": creating-middleware.md
-        - "_executing-middleware": executing-middleware.md
-        - "_api": api.md
-        - "_migration": migration.md
 site_name: laminas-stratigility
 site_description: laminas-stratigility
 repo_url: 'https://github.com/laminas/laminas-stratigility'
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        install.md: v3/install.md
+        usage.md: v3/usage.md
+        middleware.md: v3/middleware.md
+        error-handlers.md: v3/error-handlers.md
+        creating-middleware.md: v3/creating-middleware.md
+        executing-middleware.md: v3/executing-middleware.md
+        api.md: v3/api.md
+        migration.md: v3/migration.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The docs folder contains several manual redirects, i.d. HTML documents with a hard-coded redirect for legacy URLs. With the [adoption of the MkDocs redirect plugin](https://github.com/laminas/documentation-theme/pull/65) there is a simpler solution available.

This PR moves the redirects for legacy URLs in `mkdocs.yml` and removes the manually created HTML documents from Git.