### PR TITLE
Expose the internal middleware queue in `MiddlewarePipe` as an iterable

### DIFF
--- a/src/IterableMiddlewarePipeInterface.php
+++ b/src/IterableMiddlewarePipeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Stratigility;
+
+use IteratorAggregate;
+use Psr\Http\Server\MiddlewareInterface;
+
+/** @extends IteratorAggregate<int, MiddlewareInterface> */
+interface IterableMiddlewarePipeInterface extends MiddlewarePipeInterface, IteratorAggregate
+{
+}

--- a/src/IterableMiddlewarePipeInterface.php
+++ b/src/IterableMiddlewarePipeInterface.php
@@ -7,7 +7,14 @@ namespace Laminas\Stratigility;
 use IteratorAggregate;
 use Psr\Http\Server\MiddlewareInterface;
 
-/** @extends IteratorAggregate<int, MiddlewareInterface> */
+/**
+ * Implementors of this interface expose composed middleware as an iterable.
+ *
+ * This is useful for inspecting the middleware that is configured to run within a pipeline. Iterating over the pipeline
+ * should *not* cause side effects such as de-queueing any composed middleware.
+ *
+ * @extends IteratorAggregate<int, MiddlewareInterface>
+ */
 interface IterableMiddlewarePipeInterface extends MiddlewarePipeInterface, IteratorAggregate
 {
 }

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -10,6 +10,8 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use SplQueue;
 
+use function iterator_to_array;
+
 /**
  * Pipe middleware like unix pipes.
  *
@@ -83,5 +85,13 @@ final class MiddlewarePipe implements MiddlewarePipeInterface
     public function pipe(MiddlewareInterface $middleware): void
     {
         $this->pipeline->enqueue($middleware);
+    }
+
+    /** @return list<MiddlewareInterface> */
+    public function toArray(): array
+    {
+        $pipeline = clone $this->pipeline;
+
+        return iterator_to_array($pipeline, false);
     }
 }

--- a/src/MiddlewarePipe.php
+++ b/src/MiddlewarePipe.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Laminas\Stratigility;
 
+use ArrayIterator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use SplQueue;
+use Traversable;
 
 use function iterator_to_array;
 
@@ -26,7 +28,7 @@ use function iterator_to_array;
  *
  * @see https://github.com/senchalabs/connect
  */
-final class MiddlewarePipe implements MiddlewarePipeInterface
+final class MiddlewarePipe implements IterableMiddlewarePipeInterface
 {
     /** @var SplQueue<MiddlewareInterface> */
     private SplQueue $pipeline;
@@ -87,11 +89,14 @@ final class MiddlewarePipe implements MiddlewarePipeInterface
         $this->pipeline->enqueue($middleware);
     }
 
-    /** @return list<MiddlewareInterface> */
-    public function toArray(): array
+    /** @return Traversable<int, MiddlewareInterface> */
+    public function getIterator(): Traversable
     {
-        $pipeline = clone $this->pipeline;
-
-        return iterator_to_array($pipeline, false);
+        return new ArrayIterator(
+            iterator_to_array(
+                clone $this->pipeline,
+                false,
+            ),
+        );
     }
 }

--- a/src/MiddlewarePipeInterface.php
+++ b/src/MiddlewarePipeInterface.php
@@ -10,7 +10,4 @@ use Psr\Http\Server\RequestHandlerInterface;
 interface MiddlewarePipeInterface extends MiddlewareInterface, RequestHandlerInterface
 {
     public function pipe(MiddlewareInterface $middleware): void;
-
-    /** @return list<MiddlewareInterface> */
-    public function toArray(): array;
 }

--- a/src/MiddlewarePipeInterface.php
+++ b/src/MiddlewarePipeInterface.php
@@ -10,4 +10,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 interface MiddlewarePipeInterface extends MiddlewareInterface, RequestHandlerInterface
 {
     public function pipe(MiddlewareInterface $middleware): void;
+
+    /** @return list<MiddlewareInterface> */
+    public function toArray(): array;
 }

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -207,6 +207,10 @@ class MiddlewarePipeTest extends TestCase
         $methods = $r->getMethods(ReflectionMethod::IS_PUBLIC);
         $actual  = [];
         foreach ($methods as $method) {
+            if ($method->getName() === 'toArray') {
+                continue;
+            }
+
             if (strpos($method->getName(), '__') !== 0) {
                 $actual[] = $method->getName();
             }

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Stratigility;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest as Request;
 use Laminas\Stratigility\Exception;
+use Laminas\Stratigility\IterableMiddlewarePipeInterface;
 use Laminas\Stratigility\MiddlewarePipe;
 use Laminas\Stratigility\MiddlewarePipeInterface;
 use PHPUnit\Framework\TestCase;
@@ -207,17 +208,13 @@ class MiddlewarePipeTest extends TestCase
         $methods = $r->getMethods(ReflectionMethod::IS_PUBLIC);
         $actual  = [];
         foreach ($methods as $method) {
-            if ($method->getName() === 'toArray') {
-                continue;
-            }
-
             if (strpos($method->getName(), '__') !== 0) {
                 $actual[] = $method->getName();
             }
         }
         sort($actual);
 
-        $interfaceReflection = new ReflectionClass(MiddlewarePipeInterface::class);
+        $interfaceReflection = new ReflectionClass(IterableMiddlewarePipeInterface::class);
         $interfaceMethods    = $interfaceReflection->getMethods(ReflectionMethod::IS_PUBLIC);
         $expected            = [];
         foreach ($interfaceMethods as $method) {
@@ -230,7 +227,7 @@ class MiddlewarePipeTest extends TestCase
         self::assertInstanceOf(MiddlewarePipeInterface::class, $pipeline);
     }
 
-    public function testThatToArrayReturnsEnqueuedMiddlewareAsAListInQueueOrder(): void
+    public function testThatTheIteratorYieldsEnqueuedMiddlewareInQueueOrder(): void
     {
         $pipeline = new MiddlewarePipe();
         $a        = $this->createMock(MiddlewareInterface::class);
@@ -241,7 +238,7 @@ class MiddlewarePipeTest extends TestCase
         $pipeline->pipe($a);
         $pipeline->pipe($b);
 
-        self::assertSame([$c, $a, $b], $pipeline->toArray());
+        self::assertSame([$c, $a, $b], iterator_to_array($pipeline, false));
     }
 
     public function testThatCloningThePipelineAlsoClonesTheInternalQueue(): void

--- a/test/MiddlewarePipeTest.php
+++ b/test/MiddlewarePipeTest.php
@@ -17,7 +17,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionObject;
+use SplQueue;
 
+use function iterator_to_array;
 use function sort;
 use function spl_object_hash;
 use function strpos;
@@ -64,15 +66,15 @@ class MiddlewarePipeTest extends TestCase
                     static function ($argument1): bool {
                         self::assertInstanceOf(ServerRequestInterface::class, $argument1);
                         return true;
-                    }
+                    },
                 ),
                 self::callback(
                     /** @psalm-suppress MissingClosureParamType */
                     static function ($argument2): bool {
                             self::assertInstanceOf(RequestHandlerInterface::class, $argument2);
                             return true;
-                    }
-                )
+                    },
+                ),
             )
             ->willReturn($response);
 
@@ -177,12 +179,12 @@ class MiddlewarePipeTest extends TestCase
         $middleware1
             ->method('process')
             ->with(
-                $this->request
+                $this->request,
             )
             ->willReturnCallback(
                 static fn(
                     ServerRequestInterface $request,
-                    RequestHandlerInterface $handler): ResponseInterface => $handler->handle($request)
+                    RequestHandlerInterface $handler): ResponseInterface => $handler->handle($request),
             );
         $middleware2 = $this->createMock(MiddlewareInterface::class);
         $middleware2
@@ -222,5 +224,41 @@ class MiddlewarePipeTest extends TestCase
         self::assertTrue($r->isFinal());
         self::assertEquals($expected, $actual);
         self::assertInstanceOf(MiddlewarePipeInterface::class, $pipeline);
+    }
+
+    public function testThatToArrayReturnsEnqueuedMiddlewareAsAListInQueueOrder(): void
+    {
+        $pipeline = new MiddlewarePipe();
+        $a        = $this->createMock(MiddlewareInterface::class);
+        $b        = $this->createMock(MiddlewareInterface::class);
+        $c        = $this->createMock(MiddlewareInterface::class);
+
+        $pipeline->pipe($c);
+        $pipeline->pipe($a);
+        $pipeline->pipe($b);
+
+        self::assertSame([$c, $a, $b], $pipeline->toArray());
+    }
+
+    public function testThatCloningThePipelineAlsoClonesTheInternalQueue(): void
+    {
+        $pipe = new MiddlewarePipe();
+        $pipe->pipe($this->createMock(MiddlewareInterface::class));
+
+        $clone = clone $pipe;
+
+        $reflectionClass = new ReflectionClass(MiddlewarePipe::class);
+        $property        = $reflectionClass->getProperty('pipeline');
+
+        $queue1 = $property->getValue($pipe);
+        self::assertInstanceOf(SplQueue::class, $queue1);
+        $queue2 = $property->getValue($clone);
+        self::assertInstanceOf(SplQueue::class, $queue2);
+
+        self::assertNotSame($queue1, $queue2);
+        self::assertSame(
+            iterator_to_array($queue1, false),
+            iterator_to_array($queue2, false),
+        );
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| New Feature   | yes

### Description

Returns the internal `SplQueue` as an array so that users can inspect the pipeline.

Closes #44
