### PR TITLE
Allow docs to be built manually

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,7 @@
 name: docs-build
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
   repository_dispatch:


### PR DESCRIPTION
### Description

In #58 - I mistakenly targeted the current active branch 4.1.x instead of 4.0.x.

Unfortunately, I closed the milestone and released before realising, so now 4.0.1 is the same tag as 4.0 and the docs are still out of date.

Because 4.0.1 has no changes to the source, rather than move the tag, I'll just rebuild the docs manually, hence the addition of `workflow_dispatch` here.