### PR TITLE
Update middleware.md to correspond v4 changes

### DIFF
--- a/docs/book/v4/middleware.md
+++ b/docs/book/v4/middleware.md
@@ -23,7 +23,7 @@ use Laminas\Diactoros\ResponseFactory;
 use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
-use Laminas\Stratigility\Middleware\NotFoundHandler;
+use Laminas\Stratigility\Handler\NotFoundHandler;
 use Laminas\Stratigility\MiddlewarePipe;
 
 use function Laminas\Stratigility\middleware;
@@ -54,7 +54,9 @@ $app->pipe(path('/foo', middleware(function ($req, $handler) {
 })));
 
 // 404 handler
-$app->pipe(new NotFoundHandler(new ResponseFactory()));
+$app->pipe(middleware(function ($req, $handler) {
+    return (new NotFoundHandler(new ResponseFactory()))->handle($req);
+}));
 
 $server = new RequestHandlerRunner(
     $app,


### PR DESCRIPTION
Documentation improvement: Current release branch 4.2.x

Example code do not work with version v4.  Currently there is no NotFoundHandler class that implements MiddlewareInterface, so to properly handle 404 errors it has to be decorated. 