### PR TITLE
Restore ErrorHandler when listener throws exception

### DIFF
--- a/src/Middleware/ErrorHandler.php
+++ b/src/Middleware/ErrorHandler.php
@@ -126,14 +126,12 @@ class ErrorHandler implements MiddlewareInterface
         set_error_handler($this->createErrorHandler());
 
         try {
-            $response = $handler->handle($request);
+            return $handler->handle($request);
         } catch (Throwable $e) {
-            $response = $this->handleThrowable($e, $request);
+            return $this->handleThrowable($e, $request);
+        } finally {
+            restore_error_handler();
         }
-
-        restore_error_handler();
-
-        return $response;
     }
 
     /**

--- a/test/Middleware/ErrorHandlerTest.php
+++ b/test/Middleware/ErrorHandlerTest.php
@@ -18,6 +18,8 @@ use RuntimeException;
 use Throwable;
 
 use function error_reporting;
+use function restore_error_handler;
+use function set_error_handler;
 use function strlen;
 use function trigger_error;
 
@@ -327,5 +329,39 @@ class ErrorHandlerTest extends TestCase
         $listeners = $prop->getValue($middleware);
 
         self::assertCount(1, $listeners);
+    }
+
+    public function testRestoresErrorHandlerWhenListenerRaisesException(): void
+    {
+        $previousErrorHandler = static fn (): bool => false;
+        set_error_handler($previousErrorHandler);
+
+        $this->handler->method('handle')
+            ->with($this->request)
+            ->willThrowException(new RuntimeException('Exception raised', 503));
+
+        $responseGenerator = static fn (
+            Throwable $e,
+            ServerRequestInterface $request,
+            ResponseInterface $response
+        ): ResponseInterface => $response;
+
+        $middleware = new ErrorHandler($this->responseFactory, $responseGenerator);
+        $middleware->attachListener(static function (): void {
+            throw new RuntimeException('listener failure');
+        });
+
+        try {
+            $middleware->process($this->request, $this->handler);
+            self::fail('Expected listener exception');
+        } catch (RuntimeException $exception) {
+            self::assertSame('listener failure', $exception->getMessage());
+        }
+
+        $probeErrorHandler   = static fn (): bool => false;
+        $currentErrorHandler = set_error_handler($probeErrorHandler);
+        restore_error_handler();
+
+        self::assertSame($previousErrorHandler, $currentErrorHandler);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Ensure that the previous PHP error handler is always restored using a `finally` block, and add a test to verify restoration when a listener throws an exception within the `catch` block.

**Changes**:

- `src/Middleware/ErrorHandler.php`
- `test/Middleware/ErrorHandlerTest.php`

Resolves #86